### PR TITLE
Add RS-90 build target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,3 +194,9 @@ libretro-build-dingux-odbeta-mips32:
   extends:
     - .libretro-dingux-odbeta-mips32-make-default
     - .core-defs
+
+# RS-90 OpenDingux Beta
+libretro-build-rs90-odbeta-mips32:
+  extends:
+    - .libretro-rs90-odbeta-mips32-make-default
+    - .core-defs

--- a/platform/libretro/Makefile
+++ b/platform/libretro/Makefile
@@ -279,6 +279,15 @@ else ifeq ($(platform), ctr)
 	FLAGS += -DARM11 -D_3DS
 	STATIC_LINKING = 1
 
+# RS90
+else ifeq ($(platform), rs90)
+	TARGET := $(TARGET_NAME)_libretro.so
+	CC = /opt/rs90-toolchain/usr/bin/mipsel-linux-gcc
+	AR = /opt/rs90-toolchain/usr/bin/mipsel-linux-ar
+	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
+	FLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32
+	fpic := -fPIC
+
 # GCW0
 else ifeq ($(platform), gcw0)
 	TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
This PR adds a Makefile + gitlab-ci.yml target for RS-90 devices.

The core is currently untested on this platform, but given the performance of other cores I would expect it to run at full speed.

@john-parton Would you be willing to test this core?