### PR TITLE
Add optional frameskipping

### DIFF
--- a/common/supervision.h
+++ b/common/supervision.h
@@ -77,8 +77,8 @@ void supervision_done(void);
  * \return TRUE - success, FALSE - error
  */
 BOOL supervision_load(const uint8 *rom, uint32 romSize);
-void supervision_exec(uint16 *backbuffer);
-void supervision_exec_ex(uint16 *backbuffer, int16 backbufferWidth);
+void supervision_exec(uint16 *backbuffer, BOOL skipFrame);
+void supervision_exec_ex(uint16 *backbuffer, int16 backbufferWidth, BOOL skipFrame);
 
 /*!
  * \param data Bits 0-7: Right, Left, Down, Up, B, A, Select, Start.

--- a/platform/GP2X/main.c
+++ b/platform/GP2X/main.c
@@ -169,14 +169,14 @@ int main(int argc, char *argv[])
             switch(currentConfig.videoMode){
             case 0: {
                 int j;
-                supervision_exec(screenbuffer);
+                supervision_exec(screenbuffer, FALSE);
                 for (j = 0; j < 160; j++)
                     gp2x_memcpy(screen16+(80+(j+40)*320), screenbuffer+(j * 160), 160*2);
             }
                 break;
             case 1:
             case 2:
-                supervision_exec(screen16);
+                supervision_exec(screen16, FALSE);
                 break;
             default:
                 break;

--- a/platform/NDS/main.c
+++ b/platform/NDS/main.c
@@ -135,7 +135,7 @@ int main()
     while (true) {
         CheckKeys();
 
-        supervision_exec(screenBuffer);
+        supervision_exec(screenBuffer, FALSE);
 
         for (int j = 0; j < 160; j++) {
             // Copy frame buffer to screen

--- a/platform/PSP/main.c
+++ b/platform/PSP/main.c
@@ -284,7 +284,7 @@ int main(int argc, char* argv[])
             memset(&oldPad, 0xFF, sizeof(SceCtrlData)); // Reset buttons
         }
 
-        supervision_exec_ex((uint16_t*)pixels, TEX_WIDTH);
+        supervision_exec_ex((uint16_t*)pixels, TEX_WIDTH, FALSE);
 
         sceKernelDcacheWritebackAll();
 

--- a/platform/SDL/main.c
+++ b/platform/SDL/main.c
@@ -275,7 +275,7 @@ Increase Window Size: =\n\
     while (!done) {
         PollEvents();
         HandleInput();
-        supervision_exec(screenBuffer);
+        supervision_exec(screenBuffer, FALSE);
         Draw();
         Wait();
     }

--- a/platform/SDL2/main.c
+++ b/platform/SDL2/main.c
@@ -368,7 +368,7 @@ void Loop(void)
         switch (GetMenuState()) {
         case MENUSTATE_EMULATION:
             HandleInput();
-            supervision_exec(screenBuffer);
+            supervision_exec(screenBuffer, FALSE);
             break;
         case MENUSTATE_DROP_ROM:
             DrawDropROM();

--- a/platform/WIN/main.c
+++ b/platform/WIN/main.c
@@ -140,7 +140,7 @@ DWORD WINAPI run(LPVOID lpParameter)
             supervision_set_input(controls_state);
 
             while (NeedUpdate()) {
-                supervision_exec(screenBuffer);
+                supervision_exec(screenBuffer, FALSE);
 
 #ifdef TERRIBLE_AUDIO_IMPLEMENTATION
                 supervision_update_sound(audioBuffer, BUFFER_SIZE / 2);

--- a/platform/libretro/libretro_core_options.h
+++ b/platform/libretro/libretro_core_options.h
@@ -105,6 +105,43 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "0"
    },
+   {
+      "potator_frameskip",
+      "Frameskip",
+      "Skip frames to avoid audio buffer under-run (crackling). Improves performance at the expense of visual smoothness. 'Auto' skips frames when advised by the frontend. 'Manual' utilises the 'Frameskip Threshold (%)' setting.",
+      {
+         { "disabled", NULL },
+         { "auto",     "Auto" },
+         { "manual",   "Manual" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "potator_frameskip_threshold",
+      "Frameskip Threshold (%)",
+      "When 'Frameskip' is set to 'Manual', specifies the audio buffer occupancy threshold (percentage) below which frames will be skipped. Higher values reduce the risk of crackling by causing frames to be dropped more frequently.",
+      {
+         { "15", NULL },
+         { "18", NULL },
+         { "21", NULL },
+         { "24", NULL },
+         { "27", NULL },
+         { "30", NULL },
+         { "33", NULL },
+         { "36", NULL },
+         { "39", NULL },
+         { "42", NULL },
+         { "45", NULL },
+         { "48", NULL },
+         { "51", NULL },
+         { "54", NULL },
+         { "57", NULL },
+         { "60", NULL },
+         { NULL, NULL },
+      },
+      "33"
+   },
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 

--- a/platform/opendingux/main_od.c
+++ b/platform/opendingux/main_od.c
@@ -269,7 +269,7 @@ int main(int argc, char *argv[]) {
 				supervision_set_input(controls_state);
 
 				// Update emulation
-				supervision_exec(XBuf);
+				supervision_exec(XBuf, FALSE);
 				graphics_paint();
 
 				nextTick += interval;


### PR DESCRIPTION
This PR adds optional automatic frame skipping based on frontend audio buffer occupancy. A new `Frameskip` option has the following values:

- `OFF`
- `Auto`: Skips frames when the frontend reports that a buffer underrun is likely
- `Manual`: Skips frames when the audio buffer occupancy is below the percentage set via the new `Frameskip Threshold (%)` core option

With `Frameskip` set to `Auto`, essentially all games are playable even on bottom-tier hardware such as the RS-90 (even with LCD ghosting effects enabled!)