### PR TITLE
Add Potator builds for NGC, Wii, Wii U

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,6 +60,18 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/ctr-static.yml'
 
+  # Nintendo GameCube
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ngc-static.yml'
+
+  # Nintendo Wii
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/wii-static.yml'
+
+  # Nintendo WiiU
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/wiiu-static.yml'
+
   # Nintendo Switch
   - project: 'libretro-infrastructure/ci-templates'
     file: '/libnx-static.yml'
@@ -179,6 +191,24 @@ libretro-build-vita:
 libretro-build-ctr:
   extends:
     - .libretro-ctr-static-retroarch-master
+    - .core-defs
+
+# Nintendo GameCube
+libretro-build-ngc:
+  extends:
+    - .libretro-ngc-static-retroarch-master
+    - .core-defs
+    
+# Nintendo Wii
+libretro-build-wii:
+  extends:
+    - .libretro-wii-static-retroarch-master
+    - .core-defs
+
+# Nintendo WiiU
+libretro-build-wiiu:
+  extends:
+    - .libretro-wiiu-static-retroarch-master
     - .core-defs
 
 # Nintendo Switch


### PR DESCRIPTION
On all these three systems, Potator works pretty well.
This will add new builds to official Libretro of the emulator Potator for GameCube, Wii, and Wii U.

Tested and working as expected on Wii and Wii U, but it should work on GameCube too.