### PR TITLE
Fix DMA usage for 2048 game

### DIFF
--- a/common/memorymap.c
+++ b/common/memorymap.c
@@ -123,13 +123,13 @@ static void dma_write(uint32 Addr, uint8 Value)
 {
     switch (Addr & 0x1fff) {
         case 0x08: // CBUS LO
-            dma.caddr = Value;
+            dma.caddr |= Value;
             break;
         case 0x09: // CBUS HI
             dma.caddr |= (Value << 8);
             break;
         case 0x0a: // VBUS LO
-            dma.vaddr = Value;
+            dma.vaddr |= Value;
             break;
         case 0x0b: // VBUS HI
             dma.vaddr |= (Value << 8);
@@ -150,6 +150,8 @@ static void dma_write(uint32 Addr, uint8 Value)
                         Wr6502(dma.caddr + i, upperRam[dma.vaddr + i]);
                     }
                 }
+                dma.caddr = 0;
+                dma.vaddr = 0;
             }
             break;
     }


### PR DESCRIPTION
DMA is not using correct, that why my 2048 homebrew work without title screens and win/lose banners